### PR TITLE
moved localhost:5000 from template's index.html to shadow-cljs.edn

### DIFF
--- a/templates/shadow-cljs.edn
+++ b/templates/shadow-cljs.edn
@@ -1,5 +1,9 @@
 {:source-paths ["src"]
  :dependencies []
+ 
+ :dev-http {5000 "build/browser"}
+ :nrepl {:port 8777}
+ 
  :builds
   ; https://shadow-cljs.github.io/docs/UsersGuide.html#target-node-script
  {:app {:target :node-script

--- a/templates/src/_build_hooks/index.html
+++ b/templates/src/_build_hooks/index.html
@@ -5,6 +5,6 @@
     <title>ShadowCLJS</title>
   </head>
   <body>
-    <script type="text/javascript" src="http://localhost:5000/browser-main.js"></script>
+    <script type="text/javascript" src="browser-main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Thanks for the template.

I just moved the reference to localhost:5000 from the template's index.html file to
the shadow-cljs.edn

As it stood, when I pushed my app to netlify, it failed, since it tried to fetch the .js file from
localhost, rather than from the web.